### PR TITLE
feat: Parallelise picture processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "image",
  "kamadak-exif",
  "lazy_static",
+ "rayon",
  "rust-embed",
  "serde",
  "structopt",
@@ -910,21 +911,19 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,13 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/dbrgn/galerio/"
 include = [
-    "/src", "/static", "/templates",
-    "README.md", "CHANGELOG.md",
-    "LICENSE-APACHE", "LICENSE-MIT",
+    "/src",
+    "/static",
+    "/templates",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
     "screenshot.jpg",
 ]
 
@@ -25,3 +29,4 @@ serde = { version = "1", features = ["derive"] }
 structopt = { version = "0.3", default-features = false }
 tera = { version = "1.5", default-features = false }
 zip = "0.6"
+rayon = "1.7.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,7 +305,6 @@ fn main() -> Result<()> {
             }
         })
         .collect::<Vec<_>>();
-    // for f in &image_files {}
     let download_filesize_mib = download_filename
         .as_ref()
         .map(|filename| fs::metadata(args.output_dir.join(filename)).unwrap().len())


### PR DESCRIPTION
Use rayon to parallelise picture processing. Speed up 6.5x (from 31.88s to 4.93s 95 images of size ~10Mb each in a local test).